### PR TITLE
fix: Disable login redirect for direct access

### DIFF
--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -1,9 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const token = localStorage.getItem('jwt');
-    if (!token) {
-        window.location.href = 'login.html';
-        return;
-    }
+    // const token = localStorage.getItem('jwt');
+    // if (!token) {
+    //     window.location.href = 'login.html';
+    //     return;
+    // }
 
     initializeSheet();
     setupEventListeners();


### PR DESCRIPTION
Comments out the JWT token check in `main.js` to allow direct access to `index.html` without requiring a login. This is a temporary measure until the login functionality is fully implemented.