### PR TITLE
fix: Adjust spacing in 'Other Characteristics' section

### DIFF
--- a/frontend/assets/css/tabs.css
+++ b/frontend/assets/css/tabs.css
@@ -58,5 +58,5 @@
 .other-traits-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
+    gap: 8px 20px;
 }


### PR DESCRIPTION
This commit adjusts the spacing in the "Other Characteristics" section to make it more compact, as requested by the user. The vertical gap between the grid items has been reduced.