### PR TITLE
feat: Enhance 'Detalhes' tab with combat section and layout adjustments

### DIFF
--- a/frontend/assets/css/tabs.css
+++ b/frontend/assets/css/tabs.css
@@ -98,10 +98,12 @@
     text-transform: uppercase;
     color: #5a442a;
     margin-bottom: 10px;
+    margin-top: 0;
+    padding-top: 5px;
 }
 
 .armor-field {
-    margin-bottom: 10px;
+    margin-bottom: 5px;
 }
 
 .armor-field label {
@@ -114,4 +116,9 @@
     display: inline-block;
     width: 70%;
     height: 1.2em; /* To give it some height */
+}
+
+.combat-table td[contenteditable]:focus {
+    background-color: #f5f2e9;
+    outline: 1px solid #c8a46e;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -229,12 +229,12 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-                            <tr><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-                            <tr><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-                            <tr><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-                            <tr><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
-                            <tr><td></td><td></td><td></td><td></td><td></td><td></td><td></td></tr>
+                            <tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>
+                            <tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>
+                            <tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>
+                            <tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>
+                            <tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>
+                            <tr><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td><td contenteditable="true"></td></tr>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
This commit introduces several enhancements to the 'Detalhes' tab of the character sheet based on user feedback.

- **Combat and Armor Sections:** A new 'Combat' table and an 'Armor' section have been added.
- **Editable Combat Table:** The cells of the combat table are now editable, allowing users to input text directly.
- **Layout Adjustments:**
    - The "Other Characteristics" section is now a 3x3 grid with compact spacing.
    - The "Armor" section layout has been adjusted to be more vertically compact and aligned with the combat table header.