### PR TITLE
feat: Add Background tab with dynamic lists

### DIFF
--- a/frontend/assets/css/components.css
+++ b/frontend/assets/css/components.css
@@ -90,6 +90,13 @@
     color: #3a2d21;
 }
 
+.editable-list-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 4px;
+}
+
 /* New Freeform Component Styles */
 
 .freeform-column {

--- a/frontend/assets/js/components/freeformBlock.js
+++ b/frontend/assets/js/components/freeformBlock.js
@@ -1,4 +1,26 @@
 /**
+ * Creates a single editable list item with an input and a remove button.
+ * @returns {HTMLElement} The list item element.
+ */
+function createEditableListItem() {
+    const itemDiv = document.createElement('div');
+    itemDiv.className = 'editable-list-item';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'freeform-list-input';
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'remove-btn'; // Use existing style for consistency
+    removeBtn.innerHTML = '&times;';
+
+    itemDiv.appendChild(input);
+    itemDiv.appendChild(removeBtn);
+
+    return itemDiv;
+}
+
+/**
  * Creates a titled list of text inputs split into two columns.
  * @param {string} targetId - The ID of the element to append the block to.
  * @param {number} numberOfLines - The total number of text inputs to create.
@@ -35,10 +57,10 @@ function createTwoColumnTextList(targetId, numberOfLines) {
 
 
 /**
- * Creates a container with a title and a list of text inputs.
+ * Creates a container with a title, an add button, and a list of editable text inputs.
  * @param {string} targetId - The ID of the element to append the block to.
  * @param {string} title - The title to display above the list.
- * @param {number} numberOfLines - The number of text inputs to create.
+ * @param {number} numberOfLines - The initial number of text inputs to create.
  */
 function createTitledTextList(targetId, title, numberOfLines) {
     const container = document.getElementById(targetId);
@@ -48,18 +70,30 @@ function createTitledTextList(targetId, title, numberOfLines) {
     }
     container.innerHTML = ''; // Clear any placeholders
 
+    const titleContainer = document.createElement('div');
+    titleContainer.className = 'advantage-title-container'; // Use existing style for flex layout
+
     const titleElement = document.createElement('h3');
     titleElement.textContent = title;
-    container.appendChild(titleElement);
+
+    const addBtn = document.createElement('button');
+    addBtn.className = 'add-trait-btn'; // Use existing style
+    addBtn.textContent = '+';
+    // Add a specific data attribute to identify this as a freeform list add button
+    addBtn.dataset.action = 'add-list-item';
+    addBtn.dataset.target = `${targetId}-list`; // Unique target for the list
+
+    titleContainer.appendChild(titleElement);
+    titleContainer.appendChild(addBtn);
+    container.appendChild(titleContainer);
 
     const listContainer = document.createElement('div');
     listContainer.className = 'freeform-list-container';
+    listContainer.id = `${targetId}-list`; // Set ID for the add button to target
 
     for (let i = 0; i < numberOfLines; i++) {
-        const input = document.createElement('input');
-        input.type = 'text';
-        input.className = 'freeform-list-input';
-        listContainer.appendChild(input);
+        const listItem = createEditableListItem();
+        listContainer.appendChild(listItem);
     }
 
     container.appendChild(listContainer);

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -121,8 +121,12 @@ function setupEventListeners() {
             handleDotClick(event.target);
         } else if (event.target.classList.contains('health-box')) {
             handleHealthBoxClick(event.target);
+        } else if (event.target.classList.contains('remove-btn') && event.target.closest('.editable-list-item')) {
+            handleRemoveListItem(event.target);
         } else if (event.target.classList.contains('remove-btn')) {
             handleRemoveTrait(event.target);
+        } else if (event.target.classList.contains('add-trait-btn') && event.target.dataset.action === 'add-list-item') {
+            handleAddListItem(event.target);
         } else if (event.target.classList.contains('add-trait-btn')) {
             const button = event.target;
             const targetId = button.dataset.target;
@@ -189,6 +193,30 @@ function handleRemoveTrait(buttonElement) {
     const traitElement = buttonElement.closest('.trait');
     if (traitElement) {
         traitElement.remove();
+    }
+}
+
+/**
+ * Handles adding a new item to a freeform list.
+ * @param {HTMLElement} addButton - The add button that was clicked.
+ */
+function handleAddListItem(addButton) {
+    const targetId = addButton.dataset.target;
+    const listContainer = document.getElementById(targetId);
+    if (listContainer) {
+        const newItem = createEditableListItem();
+        listContainer.appendChild(newItem);
+    }
+}
+
+/**
+ * Handles removing an item from a freeform list.
+ * @param {HTMLElement} removeButton - The remove button that was clicked.
+ */
+function handleRemoveListItem(removeButton) {
+    const listItem = removeButton.closest('.editable-list-item');
+    if (listItem) {
+        listItem.remove();
     }
 }
 


### PR DESCRIPTION
This commit introduces a new "Antecedentes" (Background) tab to the Mage: The Ascension character sheet.

The new tab includes sections for:
- Expanded Background
- Possessions (Gear Carried and Equipment Owned)
- Familiar
- Grimoire
- Chantry (Location and Description)

The "Possessions" sections now feature dynamic lists, allowing users to add and remove lines as needed.

Key changes include:
- Added the new tab and content structure to `index.html`.
- Created a `freeformBlock.js` component to generate text inputs, text areas, and editable lists.
- Updated `main.js` to initialize the tab and handle add/remove events.
- Added styles to `components.css` for the new elements.