### PR TITLE
feat: Create new history tab

### DIFF
--- a/frontend/assets/css/style.css
+++ b/frontend/assets/css/style.css
@@ -143,3 +143,77 @@ section {
     outline: none;
     border-color: #5a442a;
 }
+
+/* --- History Tab --- */
+.history-section {
+    margin-bottom: 20px;
+}
+
+.history-section .section-title {
+    margin-bottom: 15px;
+}
+
+.seekings-quiets-grid,
+.description-grid,
+.visuals-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    align-items: start;
+}
+
+#history-awakening-container,
+#goals-destiny-container {
+    margin-bottom: 20px;
+}
+
+#history-awakening-container .freeform-textarea,
+#goals-destiny-container .freeform-textarea {
+    height: 150px; /* Larger text area */
+}
+
+#seekings-container .freeform-textarea,
+#quiets-container .freeform-textarea {
+    height: 100px;
+}
+
+#appearance-avatar-container .freeform-textarea {
+    height: 250px;
+}
+
+#cabal-chart-container .freeform-textarea,
+#character-sketch-container .freeform-textarea {
+    height: 180px;
+}
+
+.description-field {
+    display: flex;
+    align-items: baseline;
+    margin-bottom: 8px;
+}
+
+.description-field label {
+    font-weight: bold;
+    margin-right: 8px;
+    white-space: nowrap;
+}
+
+.description-input {
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid #3a2d21;
+    background-color: transparent;
+    font-family: 'Georgia', serif;
+    font-size: 1em;
+    padding: 2px;
+}
+
+.description-input:focus {
+    outline: none;
+    border-bottom: 1px solid #c8a46e;
+}
+
+#description-fields-container {
+    display: flex;
+    flex-direction: column;
+}

--- a/frontend/assets/js/main.js
+++ b/frontend/assets/js/main.js
@@ -64,6 +64,7 @@ function initializeSheet() {
     createCheckboxGrid('willpower-temporary', 10);
 
     initializeAntecedentesTab();
+    initializeHistoriaTab();
 }
 
 /**
@@ -353,6 +354,81 @@ function createHealthTrack(targetId, healthLevels) {
     });
 
     targetElement.appendChild(fragment);
+}
+
+/**
+ * Populates the 'História' tab with its specific components.
+ */
+function initializeHistoriaTab() {
+    // History & Goals
+    createTitledTextarea('history-awakening-container', 'História / Despertar');
+    createTitledTextarea('goals-destiny-container', 'Objetivos / Destino');
+
+    // Seekings & Quiets
+    createTitledTextarea('seekings-container', 'Buscas');
+    createTitledTextarea('quiets-container', 'Calma');
+
+    // Description
+    createTitledSection('description-section', 'Descrição');
+    createDescriptionBlock('description-fields-container');
+    createTitledTextarea('appearance-avatar-container', 'Aparência / Natureza do Avatar');
+
+    // Visuals
+    createTitledSection('visuals-section', 'Visuais');
+    createTitledTextarea('cabal-chart-container', 'Círculo');
+    createTitledTextarea('character-sketch-container', 'Esboço do Personagem');
+}
+
+
+/**
+ * Creates the description block with labels and input fields.
+ * @param {string} targetId The ID of the container element.
+ */
+function createDescriptionBlock(targetId) {
+    const container = document.getElementById(targetId);
+    if (!container) return;
+
+    const fields = [
+        "Idade:", "Idade Aparente:", "Data de Nascimento:", "Idade do Despertar:",
+        "Cabelo:", "Olhos:", "Etnia:", "Nacionalidade:", "Altura:", "Peso:", "Sexo:"
+    ];
+
+    const fragment = document.createDocumentFragment();
+
+    fields.forEach(label => {
+        const fieldDiv = document.createElement('div');
+        fieldDiv.className = 'description-field';
+
+        const labelElement = document.createElement('label');
+        labelElement.textContent = label;
+
+        const inputElement = document.createElement('input');
+        inputElement.type = 'text';
+        inputElement.className = 'description-input';
+
+        fieldDiv.appendChild(labelElement);
+        fieldDiv.appendChild(inputElement);
+        fragment.appendChild(fieldDiv);
+    });
+
+    container.appendChild(fragment);
+}
+
+/**
+ * Creates and prepends a titled section header.
+ * @param {string} containerId The ID of the container element.
+ * @param {string} title The title text.
+ */
+function createTitledSection(containerId, title) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    const titleElement = document.createElement('h2');
+    titleElement.className = 'section-title';
+    titleElement.textContent = title;
+
+    // Prepend the title to the container
+    container.insertBefore(titleElement, container.firstChild);
 }
 
 /**

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -61,6 +61,7 @@
             <button class="tab-link active" data-tab="ficha">Ficha</button>
             <button class="tab-link" data-tab="detalhes">Detalhes</button>
             <button class="tab-link" data-tab="antecedentes">Antecedentes</button>
+            <button class="tab-link" data-tab="historia">História</button>
         </div>
 
         <div id="ficha" class="tab-content active">
@@ -301,6 +302,46 @@
                  <div id="chantry-description">
                     <!-- Gerado por JS -->
                  </div>
+            </div>
+        </section>
+    </div>
+    <div id="historia" class="tab-content">
+        <section class="history-section">
+            <div id="history-awakening-container">
+                <!-- Gerado por JS -->
+            </div>
+            <div id="goals-destiny-container">
+                <!-- Gerado por JS -->
+            </div>
+        </section>
+        <section class="history-section">
+            <div class="seekings-quiets-grid">
+                <div id="seekings-container">
+                    <!-- Gerado por JS -->
+                </div>
+                <div id="quiets-container">
+                    <!-- Gerado por JS -->
+                </div>
+            </div>
+        </section>
+        <section class="history-section" id="description-section">
+            <div class="description-grid">
+                <div id="description-fields-container">
+                    <!-- Gerado por JS -->
+                </div>
+                <div id="appearance-avatar-container">
+                    <!-- Gerado por JS -->
+                </div>
+            </div>
+        </section>
+        <section class="history-section" id="visuals-section">
+            <div class="visuals-grid">
+                <div id="cabal-chart-container">
+                    <!-- Gerado por JS -->
+                </div>
+                <div id="character-sketch-container">
+                    <!-- Gerado por JS -->
+                </div>
             </div>
         </section>
     </div>


### PR DESCRIPTION
This commit introduces a new 'História' (History) tab to the character sheet.

The new tab is implemented based on the provided image and includes sections for:
- History / Awakening
- Goals / Destiny
- Seekings / Quiets
- Description (Age, Hair, Eyes, etc.)
- Visuals (Cabal Chart, Character Sketch)

The implementation follows the existing structure of the application:
- The tab and its content placeholders are added to `index.html`.
- A new JavaScript function, `initializeHistoriaTab`, is created in `main.js` to dynamically generate the content using helper functions.
- CSS styles are added to `style.css` to ensure the new tab's layout and appearance are consistent with the rest of the character sheet.

The code was reviewed and found to be correct and consistent with the existing codebase.